### PR TITLE
for consistency display weather when VideoOSD is called

### DIFF
--- a/skin.titan/1080i/Includes.xml
+++ b/skin.titan/1080i/Includes.xml
@@ -938,7 +938,7 @@
             <visible>Weather.IsFetched + Skin.HasSetting(ShowWeatherVideoInfoOSD) + !window.isactive(DialogSubtitles.xml)</visible>
 			<include>animation_fade_visible_hidden</include>
             <animation effect="slide" start="0,0" end="0,-200" condition="!Skin.HasSetting(EnableOSDInfo)">conditional</animation>
-            <animation effect="slide" start="0,0" end="0,-200" condition="Skin.HasSetting(EnableOSDInfo) + !Window.IsActive(DialogFullScreenInfo.xml)">conditional</animation>
+            <animation effect="slide" start="0,0" end="0,-200" condition="Skin.HasSetting(EnableOSDInfo) + !Window.IsActive(DialogFullScreenInfo.xml) + !Window.IsActive(VideoOSD.xml)">conditional</animation>
 			<animation effect="fade" reversible="false" end="80" time="0" condition="true">Conditional</animation>
             <!--Current Weather-->
             <control type="image">

--- a/skin.titan/1080i/VideoOSD.xml
+++ b/skin.titan/1080i/VideoOSD.xml
@@ -32,6 +32,8 @@
 				<include condition="Skin.HasTheme(classic)">OSDButtonsClassic</include>
 				<include condition="!Skin.HasTheme(classic)">OSDButtonsModern</include>
 			</control>
+			<include condition="Skin.HasSetting(ShowWeatherVideoInfoOSD) + !Skin.HasSetting(UseSlimOSDPanel) + !Skin.HasTheme(classic)">WeatherInfoOSD</include>
+			<include condition="Skin.HasSetting(ShowWeatherVideoInfoOSD) + Skin.HasSetting(UseSlimOSDPanel) + !Skin.HasTheme(classic)">WeatherInfoOSDSlim</include>
 		</control>
 		<!--Info Panel-->
         <control type="group">


### PR DESCRIPTION
for consistency display weather (when option enabled in settings) when VideoOSD is called as well as the previously enabled when DialogFullScreenInfo is called.