### PR TITLE
DialogParametricEQ.xml updated for Jarvis/Krypton

### DIFF
--- a/skin.titan/1080i/Defaults.xml
+++ b/skin.titan/1080i/Defaults.xml
@@ -142,7 +142,7 @@
         <textoffsetx>50</textoffsetx>
         <align>center</align>
         <aligny>center</aligny>
-        <reverse>no</reverse>
+        <reverse>yes</reverse>
         <pulseonselect>false</pulseonselect>
         <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="5">diffuse/panel.png</texturefocus>
         <texturenofocus colordiffuse="$INFO[Skin.String(ButtonColor)]" border="5">diffuse/panel.png</texturenofocus>
@@ -167,7 +167,7 @@
         <textoffsetx>50</textoffsetx>
         <align>center</align>
         <aligny>center</aligny>
-        <reverse>no</reverse>
+        <reverse>yes</reverse>
         <pulseonselect>false</pulseonselect>
         <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="5">diffuse/panel.png</texturefocus>
         <texturenofocus colordiffuse="$INFO[Skin.String(ButtonColor)]" border="5">diffuse/panel.png</texturenofocus>

--- a/skin.titan/1080i/DialogParametricEQ.xml
+++ b/skin.titan/1080i/DialogParametricEQ.xml
@@ -1,14 +1,13 @@
 <window>
-    <defaultcontrol always="true">3000</defaultcontrol>
+	<defaultcontrol always="true">7999</defaultcontrol>
     <controls>
-        <include>DialogOverlayExtra</include>
-        
+        <include>DialogOverlayExtra</include>        
         <control type="group">
             <include>animation_window_open_close</include>
-            <posx>367</posx>
-            <posy>236</posy>
-            <width>1190</width>
-            <height>690</height>
+			<posx>40</posx>
+			<posy>145</posy>
+            <width>1840</width>
+            <height>760</height>
             <!-- background panel -->
 			<control type="image">
 				<texture border="15">diffuse/bgpanel.png</texture>
@@ -20,265 +19,406 @@
 				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
 			</control>
             <control type="image">
-                <posx>48</posx>
-                <posy>79</posy>
-                <width>1094</width>
-                <height>481</height>
+                <posx>50</posx>
+                <posy>155</posy>
+                <width>1540</width>
+                <height>670</height>
                 <texture border="5">dialogs/default/inner.png</texture>
             </control>
-            
             <!--Header-->
 			<control type="label">
 				<description>Heading</description>
 				<posx>0</posx>
 				<posy>0</posy>
-				<width>1190</width>
+				<width>1840</width>
 				<height>80</height>
 				<label>$ADDON[adsp.biquad.filters 30100]</label>
 				<include>DialogHeader_Alt</include>
 				<align>center</align>
 				<wrapmultiline>true</wrapmultiline>
 			</control>
-            <control type="grouplist" id="3000">
-                <posx>60</posx>
-				<posy>100</posy>
-				<width>1070</width>
-                <height>450</height>
-                <onright>60</onright>
-                <onup>10000</onup>
-                <ondown>10000</ondown>
-                <onleft>10000</onleft>
-                <pagecontrol>60</pagecontrol>
-                
-                <include name="SliderEx">
-                    <param name="id" value="18000" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="10000" />
-                    <param name="downaction" value="8001" />
-                    <param name="sliderid" value="8000" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30150]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8200)]" />
-                </include>
-                <control type="label" id="8200">
-                    <description>Preamp dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>32Hz Frequency Band Slider</description>
-                    <param name="id" value="18001" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8000" />
-                    <param name="downaction" value="8002" />
-                    <param name="sliderid" value="8001" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30151]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8201)]" />
-                </include>
-
-
-                <control type="label" id="8201">
-                    <description>32Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>32Hz Frequency Band Slider</description>
-                    <param name="id" value="18002" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8001" />
-                    <param name="downaction" value="8003" />
-                    <param name="sliderid" value="8002" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30152]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8202)]" />
-                </include>
-                
-                <control type="label" id="8202">
-                    <description>64Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>128Hz Frequency Band Slider</description>
-                    <param name="id" value="18003" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8002" />
-                    <param name="downaction" value="8004" />
-                    <param name="sliderid" value="8003" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30153]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8203)]" />
-                </include>
-                <control type="label" id="8203">
-                    <description>128Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>250Hz Frequency Band Slider</description>
-                    <param name="id" value="18004" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8003" />
-                    <param name="downaction" value="8005" />
-                    <param name="sliderid" value="8004" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30154]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8204)]" />
-                </include>
-                <control type="label" id="8204">
-                    <description>250Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>500Hz Frequency Band Slider</description>
-                    <param name="id" value="18005" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8004" />
-                    <param name="downaction" value="8006" />
-                    <param name="sliderid" value="8005" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30155]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8205)]" />
-                </include>
-                <control type="label" id="8205">
-                    <description>500Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>1Khz Frequency Band Slider</description>
-                    <param name="id" value="18006" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8005" />
-                    <param name="downaction" value="8007" />
-                    <param name="sliderid" value="8006" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30156]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8206)]" />
-                </include>
-                <control type="label" id="8206">
-                    <description>1kHz dB Level</description>
-                    <label>Value</label>
-                    <info>1kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>2Khz Frequency Band Slider</description>
-                    <param name="id" value="18007" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8006" />
-                    <param name="downaction" value="8008" />
-                    <param name="sliderid" value="8007" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30157]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8207)]" />
-                </include>
-                <control type="label" id="8207">
-                    <description>2kHz dB Level</description>
-                    <label>Value</label>
-                    <info>2kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>4Khz Frequency Band Slider</description>
-                    <param name="id" value="18008" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8007" />
-                    <param name="downaction" value="8009" />
-                    <param name="sliderid" value="8008" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30158]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8208)]" />
-                </include>
-                <control type="label" id="8208">
-                    <description>4kHz dB Level</description>
-                    <label>Value</label>
-                    <info>4kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>8Khz Frequency Band Slider</description>
-                    <param name="id" value="18009" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8008" />
-                    <param name="downaction" value="8010" />
-                    <param name="sliderid" value="8009" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30159]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8209)]" />
-                </include>
-                <control type="label" id="8209">
-                    <description>8kHz dB Level</description>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>16Khz Frequency Band Slider</description>
-                    <param name="id" value="18010" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8009" />
-                    <param name="downaction" value="10000" />
-                    <param name="sliderid" value="8010" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30160]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8210)]" />
-                </include>
-                <control type="label" id="8210">
-                    <description>16kHz dB Level</description>
-                    <label>Value</label>
-                    <info>16kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-            </control>
-            
-            <control type="scrollbar" id="60">
-				<posx>1520</posx>
-				<posy>315</posy>
-				<height>480</height>
-				<onup>60</onup>
-				<ondown>60</ondown>
-				<onleft>3000</onleft>
-				<animation effect="fade" start="0" end="100" time="400" condition="Control.HasFocus(60) | Skin.HasSetting(EnableTouchSupport) | Container.Scrolling | Skin.HasSetting(alwaysShowScrollbars)">Conditional</animation>
-				<animation effect="fade" start="100" end="0" time="400" condition="![Control.HasFocus(60) | Skin.HasSetting(EnableTouchSupport) | Container.Scrolling | Skin.HasSetting(alwaysShowScrollbars)]">Conditional</animation>
-			</control>
-			
-            <!--Buttons-->
-            <control type="grouplist" id="10000">
-				<posx>130</posx>
-				<bottom>20</bottom>
-				<width>1070</width>
-				<height>80</height>
+			<control type="grouplist">
+				<description>EQ Slider Level List</description>
+				<left>40</left>
+				<top>120</top>
+				<width>1480</width>
+				<height>30</height>
+				<itemgap>15</itemgap>
 				<orientation>horizontal</orientation>
-				<onup>3000</onup>
-                <ondown>3000</ondown>
-                <onleft>10000</onleft>
-                <onright>10000</onright>
-                <control type="button" id="10050">
-                    <description>OK</description>
-					<left>0</left>
-                    <label>186</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-					<onright>7</onright>
-                </control>
-                <control type="button" id="10051">
-                    <right>0</right>
-                    <description>Cancel</description>
-                    <label>222</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-                </control>
-                <control type="button" id="10052">
-                    <right>0</right>
-                    <description>Default</description>
-                    <label>409</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-                </control>
-            </control>
+				<control type="label" id="8200">
+					<description>Preamp Frequency Band Level</description>
+					<info>Preamp Band Level</info>
+					<width>110</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8201">
+					<description>64Hz Frequency Band Level</description>
+					<info>32Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8202">
+					<description>64Hz Frequency Band Level</description>
+					<info>64Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8203">
+					<description>125Hz Frequency Band Level</description>
+					<info>125Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8204">
+					<description>250Hz Frequency Band Level</description>
+					<info>250Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8205">
+					<description>500Hz Frequency Band Level</description>
+					<info>500Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8206">
+					<description>1kHz Frequency Band Level</description>
+					<info>1kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8207">
+					<description>2kHz Frequency Band Level</description>
+					<info>2kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8208">
+					<description>4kHz Frequency Band Level</description>
+					<info>4kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8209">
+					<description>8kHz Frequency Band Level</description>
+					<info>8kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8210">
+					<description>16kHz Frequency Band Level</description>
+					<info>16kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+			</control>
+			<control type="grouplist">
+				<description>EQ Slider Label List</description>
+				<left>40</left>
+				<top>680</top>
+				<width>1480</width>
+				<height>30</height>
+				<itemgap>13</itemgap>
+				<orientation>horizontal</orientation>
+				<control type="label" id="8100">
+					<description>Preamp Frequency Band Label</description>
+					<info>Preamp Band Label</info>
+					<width>110</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30150]</label>
+				</control>
+				<control type="label" id="8101">
+					<description>64Hz Frequency Band Label</description>
+					<info>32Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30151]</label>
+				</control>
+				<control type="label" id="8102">
+					<description>64Hz Frequency Band Label</description>
+					<info>64Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30152]</label>
+				</control>
+				<control type="label" id="8103">
+					<description>125Hz Frequency Band Label</description>
+					<info>125Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30153]</label>
+				</control>
+				<control type="label" id="8104">
+					<description>250Hz Frequency Band Label</description>
+					<info>250Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30154]</label>
+				</control>
+				<control type="label" id="8105">
+					<description>500Hz Frequency Band Label</description>
+					<info>500Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30155]</label>
+				</control>
+				<control type="label" id="8106">
+					<description>1kHz Frequency Band Label</description>
+					<info>1kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30156]</label>
+				</control>
+				<control type="label" id="8107">
+					<description>2kHz Frequency Band Label</description>
+					<info>2kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30157]</label>
+				</control>
+				<control type="label" id="8108">
+					<description>4kHz Frequency Band Label</description>
+					<info>4kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30158]</label>
+				</control>
+				<control type="label" id="8109">
+					<description>8kHz Frequency Band Label</description>
+					<info>8kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30159]</label>
+				</control>
+				<control type="label" id="8110">
+					<description>16kHz Frequency Band Label</description>
+					<info>16kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30160]</label>
+				</control>
+			</control>
+			<control type="grouplist" id="7999">
+				<description>EQ Slider List</description>
+				<left>80</left>
+				<top>170</top>
+				<width>1480</width>
+				<height>670</height>
+				<onleft>10000</onleft>
+				<onright>10000</onright>
+				<onup>5</onup>
+				<ondown>1</ondown>
+				<itemgap>103</itemgap>
+				<orientation>horizontal</orientation>
+				<control type="slider" id="8000">
+					<description>Preamp Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>		 
+				<control type="slider" id="8001">
+					<description>32Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8002">
+					<description>64Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8003">
+					<description>128Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8004">
+					<description>250Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8005">
+					<description>460Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8006">
+					<description>1kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8007">
+					<description>2kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8008">
+					<description>4kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8009">
+					<description>8kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8010">
+					<description>16kHz Frequency Band Slider</description>
+					<description>rear seperation</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+			</control>	
+		<control type="grouplist" id="10000">
+			<left>1500</left>
+			<bottom>150</bottom>
+			<onup>10052</onup>
+			<ondown>10050</ondown>
+			<onleft>8010</onleft>
+			<onright>8000</onright>
+			<orientation>vertical</orientation>
+			<width>370</width>
+			<height>300</height>
+			<itemgap>10</itemgap>
+			<control type="button" id="10050">
+				<description>Ok Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>186</label>
+				<onup>10052</onup>
+				<ondown>10051</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+			<control type="button" id="10051">
+				<description>Cancel Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>222</label>
+				<onup>10050</onup>
+				<ondown>10052</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+			<control type="button" id="10052">
+				<description>Default Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>409</label>
+				<onup>10051</onup>
+				<ondown>10052</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+		</control>
         </control>
     </controls>
 </window>

--- a/skin.titan/1080i/DialogSelect.xml
+++ b/skin.titan/1080i/DialogSelect.xml
@@ -106,11 +106,25 @@
                     <width>400</width>
                     <height>140</height>
                     <font>Reg22</font>
-					<label>$INFO[Container(6).ListItem.Property(Addon.Summary),, ]$INFO[Container(6).ListItem.Label2,, ][CR]$INFO[Container(6).ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+					<label>$INFO[Container(6).ListItem.Label2,, ][CR]$INFO[Container(6).ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
 					<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
 					<shadowcolor>black</shadowcolor>
 					<align>left</align>
 					<aligny>top</aligny>
+                    <visible>!IsEmpty(ListItem.label2)</visible>
+				</control>
+                <control type="textbox">
+					<posx>1089</posx>
+                    <posy>630</posy>
+                    <width>400</width>
+                    <height>140</height>
+                    <font>Reg22</font>
+					<label>$INFO[Container(6).ListItem.Property(Addon.Summary),, ][CR]$INFO[Container(6).ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+					<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+					<shadowcolor>black</shadowcolor>
+					<align>left</align>
+					<aligny>top</aligny>
+                    <visible>IsEmpty(ListItem.label2)</visible>
 				</control>
             </control>
             <!--List-->
@@ -243,15 +257,29 @@
                     </control>
                     <control type="label">
                         <posx>120</posx>
-                        <posy>40</posy>
+                        <bottom>10</bottom>
                         <width>480</width>
-                        <height>60</height>
-                        <label>$INFO[ListItem.Property(Addon.Summary),, ]$INFO[ListItem.Label2,, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+                        <height>50</height>
+                        <label>$INFO[ListItem.Label2,, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
                         <align>left</align>
                         <aligny>center</aligny>
                         <font>Reg22</font>
                         <include>DialogListNF</include>
                         <scroll>false</scroll>
+                        <visible>!IsEmpty(ListItem.Label2)</visible>
+                    </control>
+                    <control type="label">
+                        <posx>120</posx>
+                        <bottom>10</bottom>
+                        <width>480</width>
+                        <height>50</height>
+                        <label>$INFO[ListItem.Property(Addon.Summary),, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+                        <align>left</align>
+                        <aligny>center</aligny>
+                        <font>Reg22</font>
+                        <include>DialogListNF</include>
+                        <scroll>false</scroll>
+                        <visible>IsEmpty(ListItem.Label2)</visible>
                     </control>
                     <control type="image">
                         <right>5</right>
@@ -293,15 +321,29 @@
                         </control>
                         <control type="label">
                             <posx>120</posx>
-                            <posy>40</posy>
+                            <bottom>10</bottom>
                             <width>480</width>
-                            <height>60</height>
-                            <label>$INFO[ListItem.Property(Addon.Summary),, ]$INFO[ListItem.Label2,, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+                            <height>50</height>
+                            <label>$INFO[ListItem.Label2,, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
                             <align>left</align>
                             <aligny>center</aligny>
                             <font>Reg22</font>
                             <include>DialogListFO</include>
                             <scroll>true</scroll>
+                            <visible>!IsEmpty(ListItem.Label2)</visible>
+                        </control>
+                        <control type="label">
+                            <posx>120</posx>
+                            <bottom>10</bottom>
+                            <width>480</width>
+                            <height>50</height>
+                            <label>$INFO[ListItem.Property(Addon.Summary),, ]$INFO[ListItem.Property(Addon.Version),$LOCALIZE[24051] ]</label>
+                            <align>left</align>
+                            <aligny>center</aligny>
+                            <font>Reg22</font>
+                            <include>DialogListFO</include>
+                            <scroll>true</scroll>
+                            <visible>IsEmpty(ListItem.Label2)</visible>
                         </control>
                         <control type="image">
                             <right>5</right>

--- a/skin.titan/1080i/DialogVideoInfo.xml
+++ b/skin.titan/1080i/DialogVideoInfo.xml
@@ -176,32 +176,24 @@
 							<visible>ListItem.IsResumable</visible>
                             <visible>Skin.HasSetting(videoinfo_button_play)</visible>
 						</control>
-                        
-                        <control type="button" id="244">
-							<!--Go Fullscreen-->
-							<label>244</label>
-							<width>285</width>
-							<height>60</height>
-							<align>center</align>
-							<textoffsetx>0</textoffsetx>
-							<visible>Player.HasVideo</visible>
-                            <onclick>ClearProperty(TrailerPlaying,Home)</onclick>
-                            <onclick>FullScreen</onclick>
-						</control>
 						
-						<control type="button" id="103">
-							<!-- Local Trailer-->
+						<control type="togglebutton" id="103">
+							<!-- Trailer-->
 							<width>285</width>
 							<height>60</height>
 							<align>center</align>
 							<textoffsetx>0</textoffsetx>
 							<label>20410</label>
+                            <altlabel>244</altlabel>
+                            <usealttexture>!IsEmpty(Window(Home).Property(TrailerPlaying))</usealttexture>
                             <onclick condition="Skin.String(videoinfo_traileraction,fullscreen)">FullScreen</onclick>
 							<onclick condition="Skin.String(videoinfo_traileraction,fullscreen)">PlayMedia($ESCINFO[ListItem.Trailer])</onclick>
                             <onclick condition="!Skin.String(videoinfo_traileraction,fullscreen)">PlayMedia($ESCINFO[ListItem.Trailer],1)</onclick>
-                            <onclick>SetProperty(TrailerPlaying,Playing,Home)</onclick>
+                            <onclick condition="IsEmpty(Window(Home).Property(TrailerPlaying)">SetProperty(TrailerPlaying,Playing,Home)</onclick>
+                            <onclick condition="!IsEmpty(Window(Home).Property(TrailerPlaying)">ClearProperty(TrailerPlaying,Home)</onclick>
+                            <onclick condition="!IsEmpty(Window(Home).Property(TrailerPlaying)">FullScreen</onclick>
                             <visible>Skin.HasSetting(videoinfo_button_trailer)</visible>
-							<visible>!IsEmpty(ListItem.Trailer) + IsEmpty(Window(Home).Property(TrailerPlaying))</visible>
+							<visible>!IsEmpty(ListItem.Trailer) | !IsEmpty(Window(Home).Property(TrailerPlaying))</visible>
 						</control>
 						<control type="button" id="100">
 							<!--Search Trailer on Youtube-->

--- a/skin.titan/1080i/Font.xml
+++ b/skin.titan/1080i/Font.xml
@@ -7147,7 +7147,7 @@
 		<font>
             <name>Reg24</name>
             <filename>Condensed-Regular.ttf</filename>
-            <size>24</size>
+            <size>28</size>
 		</font>
         <font>
             <name>Reg25</name>
@@ -7156,7 +7156,7 @@
         </font>
         <font>
             <name>Reg26</name>
-            <filename>Condensed-Regular.ttf</filename>
+            <filename>Condensed-Bold.ttf</filename>
             <size>26</size>
         </font>
         <font>

--- a/skin.titan/1080i/IncludesViews.xml
+++ b/skin.titan/1080i/IncludesViews.xml
@@ -1646,7 +1646,7 @@
             <posy>0</posy>
             <width>50</width>
             <height>92%</height>
-            <texture colordiffuse="$INFO[Skin.String(PVRGuideItemColorUnfocus]" border="5">diffuse/panel.png</texture>
+            <texture colordiffuse="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" border="5">diffuse/panel.png</texture>
             <visible>!Skin.HasSetting(ShowEpgGenreColors)</visible>
         </control>
         <control type="image" id="14">

--- a/skin.titan/1080i/IncludesViewsLayoutSquare.xml
+++ b/skin.titan/1080i/IncludesViewsLayoutSquare.xml
@@ -91,7 +91,8 @@
             [Control.IsVisible(510) + Skin.String(View510.Tags,enable)] | 
             !IsEmpty(ListItem.Property(defaultID)) | 
             [Control.IsVisible(509) + !Skin.String(View509.Tags) + !SubString(ListItem.Thumb,icon.png)] | 
-            [Control.IsVisible(510) + !Skin.String(View510.Tags) + !SubString(ListItem.Thumb,icon.png)]
+            [Control.IsVisible(510) + !Skin.String(View510.Tags) + !SubString(ListItem.Thumb,icon.png)] |
+            Window.IsActive(settings)
         </visible>
 	</include>
     <include name="SquarePosterTagOverlay">

--- a/skin.titan/1080i/MyPVRGuide.xml
+++ b/skin.titan/1080i/MyPVRGuide.xml
@@ -270,14 +270,14 @@
                     <!-- guide 10 rows -->
                     <channellayout height="63" width="400" condition="skin.string(GuideRows, 10) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="63" width="400" condition="skin.string(GuideRows, 10) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
@@ -289,14 +289,14 @@
                     </focusedchannellayout>
                     <channellayout height="63" width="200" condition="skin.string(GuideRows, 10) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="63" width="200" condition="skin.string(GuideRows, 10) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
@@ -316,14 +316,14 @@
                     <!-- guide 7 rows -->
                     <channellayout height="90" width="500" condition="skin.string(GuideRows, 7) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg31" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="90" width="500" condition="skin.string(GuideRows, 7) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg31" />
                         </include>
@@ -335,14 +335,14 @@
                     </focusedchannellayout>
                     <channellayout height="90" width="250" condition="skin.string(GuideRows, 7) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg31" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="90" width="250" condition="skin.string(GuideRows, 7) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg31" />
                         </include>
@@ -362,14 +362,14 @@
                     <!-- guide 8 rows -->
                     <channellayout height="79" width="500" condition="skin.string(GuideRows, 8) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="79" width="500" condition="skin.string(GuideRows, 8) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
@@ -381,14 +381,14 @@
                     </focusedchannellayout>
                     <channellayout height="79" width="250" condition="skin.string(GuideRows, 8) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="79" width="250" condition="skin.string(GuideRows, 8) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
@@ -408,14 +408,14 @@
                     <!-- guide 9 rows -->
                     <channellayout height="70" width="400" condition="skin.string(GuideRows, 9) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="70" width="400" condition="skin.string(GuideRows, 9) + !Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
@@ -427,14 +427,14 @@
                     </focusedchannellayout>
                     <channellayout height="70" width="200" condition="skin.string(GuideRows, 9) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>
                     </channellayout>
                     <focusedchannellayout height="70" width="200" condition="skin.string(GuideRows, 9) + Skin.HasSetting(HideChannelNamesInGuide)">
                         <include name="PVRGuideChannelItemLayout" content="PVRGuideChannelItemLayout" condition="!Skin.HasSetting(pvrGuideHighlightChannel)">
-                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus]" />
+                            <param name="panelcolor" value="$INFO[Skin.String(PVRGuideItemColorUnfocus)]" />
                             <param name="textcolor" value="$INFO[Skin.String(PVRGuideItemTextColorUnfocus]" />
                             <param name="font" value="Reg26" />
                         </include>

--- a/skin.titan/1080i/Settings.xml
+++ b/skin.titan/1080i/Settings.xml
@@ -14,182 +14,173 @@
         <!--Header-->
         <include>Header</include>
         <control type="group">
-		<include>animation_window_open_close</include>
-		<bottom>125</bottom>
-		<height>75%</height>
-        <!--Panel-->
-		<control type="image">
-			<posx>50</posx>
-			<width>1820</width>
-			<texture border="15">diffuse/bgpanel.png</texture>
-		<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
-		</control>
-		
-		<control type="image">
-			<posx>50</posx>
-			<width>560</width>
-			<texture border="15">diffuse/bgpanel.png</texture>
-			<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
-		</control>
-		
-        <!--Picture	(Fanart)-->
-        <control type="image">
-            <posx>660</posx>
-            <posy>30</posy>
-            <width>1160</width>
-            <height>540</height>
-            <texture background="true">$INFO[Container(9000).ListItem.Property(image)]</texture>
-            <aspectratio>scale</aspectratio>
+            <include>animation_window_open_close</include>
+            <bottom>125</bottom>
+            <height>75%</height>
+            <!--Panel-->
+            <control type="image">
+                <posx>50</posx>
+                <width>1820</width>
+                <texture border="15">diffuse/bgpanel.png</texture>
+            <colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+            </control>
+            
+            <control type="image">
+                <posx>50</posx>
+                <width>560</width>
+                <texture border="15">diffuse/bgpanel.png</texture>
+                <colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+            </control>
+            
+            <!--Picture	(Fanart)-->
+            <control type="image">
+                <posx>80</posx>
+                <posy>30</posy>
+                <width>500</width>
+                <height>300</height>
+                <texture background="true">$INFO[Container(9000).ListItem.ActualIcon]</texture>
+                <aspectratio>scale</aspectratio>
+            </control>
+            
+            <!--InfoText-->
+            <control type="textbox">
+                <posx>80</posx>
+                <posy>360</posy>
+                <width>500</width>
+                <height>250</height>
+                <font>Light30</font>
+                <align>left</align>
+                <label>$INFO[Container(9000).ListItem.Label2]</label>
+            </control>
+            
+            
+            
+            <!--List 9000-->
+            <control type="panel" id="9000">
+                <viewtype label="31437">icons</viewtype>
+                <right>80</right>
+                <top>20</top>
+                <height>780</height>
+                <width>1200</width>
+                <orientation>vertical</orientation>
+                <onup>9000</onup>
+                <ondown>9000</ondown>
+                <preloaditems>4</preloaditems>
+                <itemlayout height="260" width="300">
+                    <control type="group">
+                        <width>280</width>
+                        <height>240</height>
+                        <include>SquarePosterPanelLayout</include>
+                    </control>
+                </itemlayout>
+                <focusedlayout height="260" width="300">
+                    <control type="group">
+                        <width>280</width>
+                        <height>240</height>
+                        <include>SquarePosterPanelLayoutFocus</include>
+                    </control>
+                </focusedlayout>
+                <content>
+                    <item id="11">
+                        <description>Skin Settings</description>
+                        <label>20077</label>
+                        <label2>31407</label2>
+                        <onclick>activatewindow(skinsettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/appearance.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonskin.png</thumb>
+                    </item>
+                    <item id="1">
+                        <description>Appearance</description>
+                        <label>480</label>
+                        <label2>31400</label2>
+                        <onclick>activatewindow(AppearanceSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/appearance.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonpictures.png</thumb>
+                    </item>
+                    <item id="2">
+                        <description>Videos</description>
+                        <label>3</label>
+                        <label2>31401</label2>
+                        <onclick>activatewindow(VideosSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/videos.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonvideo.png</thumb>
+                    </item>
+                    <item id="3">
+                        <description>Live TV</description>
+                        <label>31088</label>
+                        <label2>31410</label2>
+                        <onclick>ActivateWindow(PVRSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/pvr.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonpvrclient.png</thumb>
+                    </item>
+                    <item id="4">
+                        <description>Music</description>
+                        <label>2</label>
+                        <label2>31402</label2>
+                        <onclick>ActivateWindow(MusicSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/music.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonmusic.png</thumb>
+                    </item>
+                    <item id="5">
+                        <description>Addons</description>
+                        <label>24001</label>
+                        <label2>31408</label2>
+                        <onclick>activatewindow(AddonBrowser)</onclick>
+                        <icon>special://skin/extras/backgrounds/addons.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultprogram.png</thumb>
+                    </item>
+                    <item id="6">
+                        <description>Pictures</description>
+                        <label>1</label>
+                        <label2>31403</label2>
+                        <onclick>activatewindow(PicturesSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/pictures.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultpicture.png</thumb>
+                    </item>
+                    <item id="7">
+                        <description>Weather</description>
+                        <label>8</label>
+                        <label2>31404</label2>
+                        <onclick>activatewindow(WeatherSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/weather.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonweather.png</thumb>
+                    </item>
+                    <item id="8">
+                        <description>Network/Services</description>
+                        <label>14036</label>
+                        <label2>31405</label2>
+                        <onclick>activatewindow(ServiceSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/network.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultaddonservice.png</thumb>
+                    </item>
+                    <item id="9">
+                        <description>System</description>
+                        <label>13000</label>
+                        <label2>31406</label2>
+                        <onclick>activatewindow(SystemSettings)</onclick>
+                        <icon>special://skin/extras/backgrounds/system.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultharddisk.png</thumb>
+                    </item>
+                    <item id="10">
+                        <description>System Info</description>
+                        <label>130</label>
+                        <label2>31409</label2>
+                        <onclick>activatewindow(7)</onclick>
+                        <icon>special://skin/extras/backgrounds/systeminfo.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/cpu.png</thumb>
+                    </item>
+                    <item id="12">
+                        <description>Profiles</description>
+                        <label>13200</label>
+                        <label2>31421</label2>
+                        <onclick>activatewindow(Profiles)</onclick>
+                        <icon>special://skin/extras/backgrounds/settings.jpg</icon>
+                        <thumb>special://skin/extras/defaulticonswide/defaultactor.png</thumb>
+                    </item>
+                </content>
+            </control>
+            
         </control>
-        
-        <!--InfoText-->
-        <control type="textbox">
-            <posx>660</posx>
-            <posy>610</posy>
-            <width>1160</width>
-            <height>250</height>
-            <font>Light30</font>
-            <label>$INFO[Container(9000).ListItem.Label2]</label>
-        </control>
-        
-        
-        
-        <!--List 9000-->
-        <control type="list" id="9000">
-            <posx>130</posx>
-            <posy>20</posy>
-            <!--175-->
-            <width>420</width>
-            <height>800</height>
-            <onup>9000</onup>
-            <ondown>9000</ondown>
-            <viewtype label="List">list</viewtype>
-            <scrolltime>200</scrolltime>
-            <include>animation_fade_visible_hidden</include>
-
-			<itemlayout width="420" height="64">
-                <control type="image">
-                    <!--Button No Focus-->
-                    <width>420</width>
-                    <height>60</height>
-					<texture border="5" colordiffuse="$INFO[Skin.String(ButtonColor)]">diffuse/panel.png</texture>
-                </control>
-                <control type="label">
-                    <!--Label No Focus-->
-                    <height>67</height>
-                    <posx>70</posx>
-                    <width>360</width>
-                    <font>Reg30</font>
-                    <textcolor>$INFO[Skin.String(ButtonTextColor)]</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
-                </control>
-            </itemlayout>
-            <focusedlayout width="420" height="64">
-                <control type="image">
-                    <!--Button Focus-->
-                    <width>420</width>
-                    <height>60</height>
-                    <texture diffuse="diffuse/panel.png" border="5" colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texture>
-                </control>
-                <control type="label">
-                    <!--Label Focus-->
-                    <height>67</height>
-                    <posx>70</posx>
-                    <width>360</width>
-                    <font>Reg30</font>
-                    <textcolor>$INFO[Skin.String(ButtonFocusTextColor)]</textcolor>
-                    <label>$INFO[ListItem.Label]</label>
-                </control>
-            </focusedlayout>
-     			<!--Content-->
-            <content>
-				<item id="11">
-					<description>Skin Settings</description>
-					<label>20077</label>
-					<label2>31407</label2>
-					<onclick>activatewindow(skinsettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/appearance.jpg</property>
-				</item>
-                <item id="1">
-                    <description>Appearance</description>
-                    <label>480</label>
-                    <label2>31400</label2>
-                    <onclick>activatewindow(AppearanceSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/appearance.jpg</property>
-                </item>
-                <item id="2">
-                    <description>Videos</description>
-                    <label>3</label>
-                    <label2>31401</label2>
-                    <onclick>activatewindow(VideosSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/videos.jpg</property>
-                </item>
-                <item id="3">
-                    <description>Live TV</description>
-                    <label>31088</label>
-                    <label2>31410</label2>
-                    <onclick>ActivateWindow(PVRSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/pvr.jpg</property>
-                </item>
-                <item id="4">
-                    <description>Music</description>
-                    <label>2</label>
-                    <label2>31402</label2>
-                    <onclick>ActivateWindow(MusicSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/music.jpg</property>
-                </item>
-                <item id="5">
-                    <description>Addons</description>
-                    <label>24001</label>
-                    <label2>31408</label2>
-                    <onclick>activatewindow(AddonBrowser)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/addons.jpg</property>
-                </item>
-                <item id="6">
-                    <description>Pictures</description>
-                    <label>1</label>
-                    <label2>31403</label2>
-                    <onclick>activatewindow(PicturesSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/pictures.jpg</property>
-                </item>
-                <item id="7">
-                    <description>Weather</description>
-                    <label>8</label>
-                    <label2>31404</label2>
-                    <onclick>activatewindow(WeatherSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/weather.jpg</property>
-                </item>
-                <item id="8">
-                    <description>Network/Services</description>
-                    <label>14036</label>
-                    <label2>31405</label2>
-                    <onclick>activatewindow(ServiceSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/network.jpg</property>
-                </item>
-                <item id="9">
-                    <description>System</description>
-                    <label>13000</label>
-                    <label2>31406</label2>
-                    <onclick>activatewindow(SystemSettings)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/system.jpg</property>
-                </item>
-                <item id="10">
-                    <description>System Info</description>
-                    <label>130</label>
-                    <label2>31409</label2>
-                    <onclick>activatewindow(7)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/systeminfo.jpg</property>
-                </item>
-                <item id="12">
-					<description>Profiles</description>
-					<label>13200</label>
-					<label2>31421</label2>
-					<onclick>activatewindow(Profiles)</onclick>
-                    <property name="image">special://skin/extras/backgrounds/settings.jpg</property>
-				</item>
-            </content>
-        </control>
-		</control>
 		
 		<!--Footer-->
         <include condition="!skin.hassetting(nofooterbar)">Footer</include>

--- a/skin.titan/1080i/Settings.xml
+++ b/skin.titan/1080i/Settings.xml
@@ -95,7 +95,7 @@
                         <label2>31400</label2>
                         <onclick>activatewindow(AppearanceSettings)</onclick>
                         <icon>special://skin/extras/backgrounds/appearance.jpg</icon>
-                        <thumb>special://skin/extras/defaulticonswide/defaultaddonpictures.png</thumb>
+                        <thumb>special://skin/extras/defaulticonswide/defaultcountry.png</thumb>
                     </item>
                     <item id="2">
                         <description>Videos</description>


### PR DESCRIPTION
DialogParametricEQ.xml updated for Jarvis/Krypton

DialogParametricEQ.xml was not working on Krypton version of skin so I made a version that does.

Should work with Jarvis as well - will test and update the comments in this PR if it does not.

### **Note**: changed to using slider (not sliderex) controls - so this PR is using the changes in PR #232

feel free to move the button group for ok/cancel/defaults to wherever you like - wasn't sure if center or bottom was preferred, 

**screenshot of new dialog in Krypton rev of the skin:**

![2016-09-11_20-23-47](https://cloud.githubusercontent.com/assets/6510026/18423910/826e006e-785e-11e6-80d3-a424ded795dc.png)
