### PR TITLE
DialogParametricEQ.xml updated for Krypton

### DIFF
--- a/skin.titan/1080i/DialogParametricEQ.xml
+++ b/skin.titan/1080i/DialogParametricEQ.xml
@@ -1,14 +1,13 @@
 <window>
-    <defaultcontrol always="true">3000</defaultcontrol>
+	<defaultcontrol always="true">7999</defaultcontrol>
     <controls>
-        <include>DialogOverlayExtra</include>
-        
+        <include>DialogOverlayExtra</include>        
         <control type="group">
             <include>animation_window_open_close</include>
-            <posx>367</posx>
-            <posy>236</posy>
-            <width>1190</width>
-            <height>690</height>
+			<posx>40</posx>
+			<posy>145</posy>
+            <width>1840</width>
+            <height>760</height>
             <!-- background panel -->
 			<control type="image">
 				<texture border="15">diffuse/bgpanel.png</texture>
@@ -20,265 +19,406 @@
 				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
 			</control>
             <control type="image">
-                <posx>48</posx>
-                <posy>79</posy>
-                <width>1094</width>
-                <height>481</height>
+                <posx>50</posx>
+                <posy>155</posy>
+                <width>1540</width>
+                <height>670</height>
                 <texture border="5">dialogs/default/inner.png</texture>
             </control>
-            
             <!--Header-->
 			<control type="label">
 				<description>Heading</description>
 				<posx>0</posx>
 				<posy>0</posy>
-				<width>1190</width>
+				<width>1840</width>
 				<height>80</height>
 				<label>$ADDON[adsp.biquad.filters 30100]</label>
 				<include>DialogHeader_Alt</include>
 				<align>center</align>
 				<wrapmultiline>true</wrapmultiline>
 			</control>
-            <control type="grouplist" id="3000">
-                <posx>60</posx>
-				<posy>100</posy>
-				<width>1070</width>
-                <height>450</height>
-                <onright>60</onright>
-                <onup>10000</onup>
-                <ondown>10000</ondown>
-                <onleft>10000</onleft>
-                <pagecontrol>60</pagecontrol>
-                
-                <include name="SliderEx">
-                    <param name="id" value="18000" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="10000" />
-                    <param name="downaction" value="8001" />
-                    <param name="sliderid" value="8000" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30150]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8200)]" />
-                </include>
-                <control type="label" id="8200">
-                    <description>Preamp dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>32Hz Frequency Band Slider</description>
-                    <param name="id" value="18001" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8000" />
-                    <param name="downaction" value="8002" />
-                    <param name="sliderid" value="8001" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30151]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8201)]" />
-                </include>
-
-
-                <control type="label" id="8201">
-                    <description>32Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>32Hz Frequency Band Slider</description>
-                    <param name="id" value="18002" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8001" />
-                    <param name="downaction" value="8003" />
-                    <param name="sliderid" value="8002" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30152]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8202)]" />
-                </include>
-                
-                <control type="label" id="8202">
-                    <description>64Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                
-                <include name="SliderEx">
-                    <description>128Hz Frequency Band Slider</description>
-                    <param name="id" value="18003" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8002" />
-                    <param name="downaction" value="8004" />
-                    <param name="sliderid" value="8003" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30153]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8203)]" />
-                </include>
-                <control type="label" id="8203">
-                    <description>128Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>250Hz Frequency Band Slider</description>
-                    <param name="id" value="18004" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8003" />
-                    <param name="downaction" value="8005" />
-                    <param name="sliderid" value="8004" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30154]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8204)]" />
-                </include>
-                <control type="label" id="8204">
-                    <description>250Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>500Hz Frequency Band Slider</description>
-                    <param name="id" value="18005" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8004" />
-                    <param name="downaction" value="8006" />
-                    <param name="sliderid" value="8005" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30155]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8205)]" />
-                </include>
-                <control type="label" id="8205">
-                    <description>500Hz dB Level</description>
-                    <label>Value</label>
-                    <info>32Hz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>1Khz Frequency Band Slider</description>
-                    <param name="id" value="18006" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8005" />
-                    <param name="downaction" value="8007" />
-                    <param name="sliderid" value="8006" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30156]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8206)]" />
-                </include>
-                <control type="label" id="8206">
-                    <description>1kHz dB Level</description>
-                    <label>Value</label>
-                    <info>1kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>2Khz Frequency Band Slider</description>
-                    <param name="id" value="18007" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8006" />
-                    <param name="downaction" value="8008" />
-                    <param name="sliderid" value="8007" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30157]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8207)]" />
-                </include>
-                <control type="label" id="8207">
-                    <description>2kHz dB Level</description>
-                    <label>Value</label>
-                    <info>2kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>4Khz Frequency Band Slider</description>
-                    <param name="id" value="18008" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8007" />
-                    <param name="downaction" value="8009" />
-                    <param name="sliderid" value="8008" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30158]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8208)]" />
-                </include>
-                <control type="label" id="8208">
-                    <description>4kHz dB Level</description>
-                    <label>Value</label>
-                    <info>4kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>8Khz Frequency Band Slider</description>
-                    <param name="id" value="18009" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8008" />
-                    <param name="downaction" value="8010" />
-                    <param name="sliderid" value="8009" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30159]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8209)]" />
-                </include>
-                <control type="label" id="8209">
-                    <description>8kHz dB Level</description>
-                    <visible>false</visible>
-                </control>
-                <include name="SliderEx">
-                    <description>16Khz Frequency Band Slider</description>
-                    <param name="id" value="18010" />
-                    <param name="width" value="1070" />
-                    <param name="upaction" value="8009" />
-                    <param name="downaction" value="10000" />
-                    <param name="sliderid" value="8010" />
-                    <param name="label" value="$ADDON[adsp.biquad.filters 30160]" />
-                    <param name="label2" value="$INFO[Control.GetLabel(8210)]" />
-                </include>
-                <control type="label" id="8210">
-                    <description>16kHz dB Level</description>
-                    <label>Value</label>
-                    <info>16kHz Band Value</info>
-                    <visible>false</visible>
-                </control>
-            </control>
-            
-            <control type="scrollbar" id="60">
-				<posx>1520</posx>
-				<posy>315</posy>
-				<height>480</height>
-				<onup>60</onup>
-				<ondown>60</ondown>
-				<onleft>3000</onleft>
-				<animation effect="fade" start="0" end="100" time="400" condition="Control.HasFocus(60) | Skin.HasSetting(EnableTouchSupport) | Container.Scrolling | Skin.HasSetting(alwaysShowScrollbars)">Conditional</animation>
-				<animation effect="fade" start="100" end="0" time="400" condition="![Control.HasFocus(60) | Skin.HasSetting(EnableTouchSupport) | Container.Scrolling | Skin.HasSetting(alwaysShowScrollbars)]">Conditional</animation>
-			</control>
-			
-            <!--Buttons-->
-            <control type="grouplist" id="10000">
-				<posx>130</posx>
-				<bottom>20</bottom>
-				<width>1070</width>
-				<height>80</height>
+			<control type="grouplist">
+				<description>EQ Slider Level List</description>
+				<left>40</left>
+				<top>120</top>
+				<width>1480</width>
+				<height>30</height>
+				<itemgap>15</itemgap>
 				<orientation>horizontal</orientation>
-				<onup>3000</onup>
-                <ondown>3000</ondown>
-                <onleft>10000</onleft>
-                <onright>10000</onright>
-                <control type="button" id="10050">
-                    <description>OK</description>
-					<left>0</left>
-                    <label>186</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-					<onright>7</onright>
-                </control>
-                <control type="button" id="10051">
-                    <right>0</right>
-                    <description>Cancel</description>
-                    <label>222</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-                </control>
-                <control type="button" id="10052">
-                    <right>0</right>
-                    <description>Default</description>
-                    <label>409</label>
-                    <width>300</width>
-                    <include>DialogButtonOther</include>
-                    <height>80</height>
-                </control>
-            </control>
+				<control type="label" id="8200">
+					<description>Preamp Frequency Band Level</description>
+					<info>Preamp Band Level</info>
+					<width>110</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8201">
+					<description>64Hz Frequency Band Level</description>
+					<info>32Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8202">
+					<description>64Hz Frequency Band Level</description>
+					<info>64Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8203">
+					<description>125Hz Frequency Band Level</description>
+					<info>125Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8204">
+					<description>250Hz Frequency Band Level</description>
+					<info>250Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8205">
+					<description>500Hz Frequency Band Level</description>
+					<info>500Hz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8206">
+					<description>1kHz Frequency Band Level</description>
+					<info>1kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8207">
+					<description>2kHz Frequency Band Level</description>
+					<info>2kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8208">
+					<description>4kHz Frequency Band Level</description>
+					<info>4kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8209">
+					<description>8kHz Frequency Band Level</description>
+					<info>8kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+				<control type="label" id="8210">
+					<description>16kHz Frequency Band Level</description>
+					<info>16kHz Band Level</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+				</control>
+			</control>
+			<control type="grouplist">
+				<description>EQ Slider Label List</description>
+				<left>40</left>
+				<top>680</top>
+				<width>1480</width>
+				<height>30</height>
+				<itemgap>13</itemgap>
+				<orientation>horizontal</orientation>
+				<control type="label" id="8100">
+					<description>Preamp Frequency Band Label</description>
+					<info>Preamp Band Label</info>
+					<width>110</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30150]</label>
+				</control>
+				<control type="label" id="8101">
+					<description>64Hz Frequency Band Label</description>
+					<info>32Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30151]</label>
+				</control>
+				<control type="label" id="8102">
+					<description>64Hz Frequency Band Label</description>
+					<info>64Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30152]</label>
+				</control>
+				<control type="label" id="8103">
+					<description>125Hz Frequency Band Label</description>
+					<info>125Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30153]</label>
+				</control>
+				<control type="label" id="8104">
+					<description>250Hz Frequency Band Label</description>
+					<info>250Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30154]</label>
+				</control>
+				<control type="label" id="8105">
+					<description>500Hz Frequency Band Label</description>
+					<info>500Hz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30155]</label>
+				</control>
+				<control type="label" id="8106">
+					<description>1kHz Frequency Band Label</description>
+					<info>1kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30156]</label>
+				</control>
+				<control type="label" id="8107">
+					<description>2kHz Frequency Band Label</description>
+					<info>2kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30157]</label>
+				</control>
+				<control type="label" id="8108">
+					<description>4kHz Frequency Band Label</description>
+					<info>4kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30158]</label>
+				</control>
+				<control type="label" id="8109">
+					<description>8kHz Frequency Band Label</description>
+					<info>8kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30159]</label>
+				</control>
+				<control type="label" id="8110">
+					<description>16kHz Frequency Band Label</description>
+					<info>16kHz Band Label</info>
+					<width>120</width>
+					<height>30</height>
+					<visible>true</visible>
+					<align>center</align>
+					<aligny>center</aligny>
+					<scroll>false</scroll>
+					<label>$ADDON[adsp.biquad.filters 30160]</label>
+				</control>
+			</control>
+			<control type="grouplist" id="7999">
+				<description>EQ Slider List</description>
+				<left>80</left>
+				<top>170</top>
+				<width>1480</width>
+				<height>670</height>
+				<onleft>10000</onleft>
+				<onright>10000</onright>
+				<onup>5</onup>
+				<ondown>1</ondown>
+				<itemgap>103</itemgap>
+				<orientation>horizontal</orientation>
+				<control type="slider" id="8000">
+					<description>Preamp Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>		 
+				<control type="slider" id="8001">
+					<description>32Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8002">
+					<description>64Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8003">
+					<description>128Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8004">
+					<description>250Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8005">
+					<description>460Hz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8006">
+					<description>1kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8007">
+					<description>2kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8008">
+					<description>4kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8009">
+					<description>8kHz Frequency Band Slider</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+				<control type="slider" id="8010">
+					<description>16kHz Frequency Band Slider</description>
+					<description>rear seperation</description>
+					<height>500</height>
+					<width>30</width>
+					<aligny>center</aligny>
+					<orientation>vertical</orientation>
+				</control>
+			</control>	
+		<control type="grouplist" id="10000">
+			<left>1500</left>
+			<bottom>150</bottom>
+			<onup>10052</onup>
+			<ondown>10050</ondown>
+			<onleft>8010</onleft>
+			<onright>8000</onright>
+			<orientation>vertical</orientation>
+			<width>370</width>
+			<height>300</height>
+			<itemgap>10</itemgap>
+			<control type="button" id="10050">
+				<description>Ok Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>186</label>
+				<onup>10052</onup>
+				<ondown>10051</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+			<control type="button" id="10051">
+				<description>Cancel Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>222</label>
+				<onup>10050</onup>
+				<ondown>10052</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+			<control type="button" id="10052">
+				<description>Default Button</description>
+				<width>300</width>
+                <height>80</height>
+				<align>center</align>
+				<label>409</label>
+				<onup>10051</onup>
+				<ondown>10052</ondown>
+				<include>DialogButtonOther</include>
+			</control>
+		</control>
         </control>
     </controls>
 </window>


### PR DESCRIPTION
Had to close previous PR based on Jarvis branch and re-open on krypton branch.

NOTE: 
- Does not work on Jarvis (but the current Jarvis xml works just fine as is anyway).
- relies on changes to slider and sliderex made in https://github.com/marcelveldt/skin.titan/pull/232 to look right.

screenshot of dialog in krypton beta:

![826e006e-785e-11e6-80d3-a424ded795dc](https://cloud.githubusercontent.com/assets/6510026/18437168/7a662f2a-78b0-11e6-9373-e9bd696e01ee.png)
