### PR TITLE
add missing aspectratio/zoom info overlay

### DIFF
--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -5,5 +5,59 @@
 	<onload condition="Skin.HasSetting(DisableSubtitles) + VideoPlayer.SubtitlesEnabled">ShowSubtitles</onload>
     <onunload condition="![Player.HasVideo + VideoPlayer.Content(livetv)]">ClearProperty(pvrGuideOnFullscreenVideo,home)</onunload>
     <controls>
+		<control type="image">
+			<left>0</left>
+			<top>300</top>
+			<width>100%</width>
+			<height>275</height>
+			<texture border="5">diffuse/panel.png</texture>
+			<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
+			<animation effect="slide" start="0,0" end="0,-200" time="0" condition="![Control.isVisible(11) + Control.IsVisible(12)]">Conditional</animation>
+		</control>
+
+	<!-- Aspect Ratio / Zoom Info Overlay -->
+
+	<control type="group">
+			<left>0</left>
+			<top>300</top>
+			<width>100%</width>
+			<height>275</height>
+
+			<!-- Row 1 label -->
+			<control type="label" id="10">
+				<left>20%</left>
+				<top>20</top>
+				<width>60%</width>
+				<height>50</height>
+				<font>Bold30</font>
+				<textcolor>white</textcolor>
+				<shadowcolor>black</shadowcolor>
+				<label>-</label>
+			</control>
+
+			<!-- Row 2 label -->
+			<control type="label" id="11">
+				<left>20%</left>
+				<top>110</top>
+				<width>60%</width>
+				<height>50</height>
+				<font>Bold30</font>
+				<textcolor>white</textcolor>
+				<label>-</label>
+			</control>
+
+			<!-- Row 3 label -->
+			<control type="label" id="12">
+				<left>20%</left>
+				<top>200</top>
+				<width>60%</width>
+				<height>50</height>
+				<font>Bold30</font>
+				<textcolor>white</textcolor>
+				<label>-</label>
+			</control>
+
+		</control>
+
     </controls>
 </window>

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -12,7 +12,6 @@
 			<height>275</height>
 			<texture border="5">diffuse/panel.png</texture>
 			<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
-			<animation effect="slide" start="0,0" end="0,-200" time="0" condition="![Control.isVisible(11) + Control.IsVisible(12)]">Conditional</animation>
 		</control>
 
 	<!-- Aspect Ratio / Zoom Info Overlay -->


### PR DESCRIPTION
It seems it was removed from the krypton branch of the skin at some point - this functionality works fine in previous branches 

so added a simple overlay for zoom/aspect ratio info to display (briefly) or as it is changed by cycling modes

this happens when the default keymap Z is pressed (once or more to cycle modes) during video playback

see screenshots below of overlay being displayed when OSD Info and/or Controls are visible and when not during video playback

![2016-12-01_04-55-44](https://cloud.githubusercontent.com/assets/6510026/20795566/aa9e584c-b786-11e6-8b70-a4798b62f270.png)

![2016-12-01_04-56-24](https://cloud.githubusercontent.com/assets/6510026/20795567/aaa09f1c-b786-11e6-9763-3af5546db7d0.png)
