### PR TITLE
Per Trello card request adding player cache/buffer level to Process I…

### DIFF
--- a/1080i/DialogPlayerProcessInfo.xml
+++ b/1080i/DialogPlayerProcessInfo.xml
@@ -572,6 +572,37 @@
 					<font>Reg26</font>
 					<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
 				</control>
+				<control type="label">
+					<description>CacheLevel</description>
+					<left>45</left>
+					<top>310</top>
+					<width>250</width>
+					<height>25</height>
+					<label>$LOCALIZE[14200] $LOCALIZE[439]: </label> 
+					<align>left</align>
+					<aligny>center</aligny>
+					<font>Reg26</font>
+				</control>
+				<control type="progress">
+					<description>Progressbar</description>
+					<left>270</left>
+					<top>317</top>
+					<width>275</width>
+					<height>14</height>
+					<info>Player.CacheLevel</info>
+				</control>
+				<control type="label">
+					<description>CacheLevel</description>
+					<left>555</left>
+					<top>310</top>
+					<width>800</width>
+					<height>25</height>
+					<label>$INFO[Player.CacheLevel]%</label>
+					<align>left</align>
+					<aligny>center</aligny>
+					<font>Reg26</font>
+					<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+				</control>
 			</control>
 			<control type="grouplist" id="5550">
 				<right>5</right>


### PR DESCRIPTION
…nfo Dialog

Adding what I can at least per the request.  User will have to rely on control-shift-O (playerdebug overlay) for other info until devs expose the info to skins via info labels, etc.

![screenshot000](https://cloud.githubusercontent.com/assets/6510026/21461765/99a4d6da-c909-11e6-94d6-4c63653978f4.png)
