### PR TITLE
add fallback(s) for $VAR VideoPlayerClearArt

### DIFF
--- a/1080i/IncludesVariables.xml
+++ b/1080i/IncludesVariables.xml
@@ -613,6 +613,10 @@
 	<value condition="!IsEmpty(Player.Art(tvshow.clearlogo))">$INFO[Player.Art(tvshow.clearlogo)]</value>
     <value condition="!IsEmpty(Window(Home).Property(SkinHelper.Player.Art.ClearArt))">$INFO[Window(Home).Property(SkinHelper.Player.Art.ClearArt)]</value>
 	<value condition="!IsEmpty(Window(Home).Property(SkinHelper.Player.Art.ClearLogo))">$INFO[Window(Home).Property(SkinHelper.Player.Art.ClearLogo)]</value>
+	<value condition="VideoPlayer.Content(episodes) + !String.IsEmpty(Player.Art(tvshow.poster))">$INFO[Player.Art(tvshow.poster)]</value>
+	<value condition="VideoPlayer.Content(episodes) + !String.IsEmpty(Player.Art(tvshow.thumb))">$INFO[Player.Art(tvshow.thumb)]</value>
+	<value condition="!IsEmpty(Player.Art(poster))">$INFO[Player.Art(poster)]</value>
+	<value>$INFO[Player.Art(thumb)]</value>
    </variable>
    
    <variable name="VideoPlayerPoster">


### PR DESCRIPTION
This PR is just a proposed work around (you can decline and it won't bother me 😄 hehe)

PR: add fallback(s) for $VAR VideoPlayerClearArt for OSD display.

reason for PR:  i don't think you can do an is empty check on a $VAR - so figured this could be a workaround to display _something_ when setting is enabled...

thoughts?
# 
**Also Related Question...** 

in DialogSeekbar.xml the visibility condition for this image control has "!Control.IsVisible(552233)" - should that be omitted?