### PR TITLE
Krypton specific settings icon update

### DIFF
--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -103,7 +103,7 @@
                         <label2>14212</label2>
                         <onclick>activatewindow(MediaSettings)</onclick>
                         <icon>resource://resource.images.skinbackgrounds.titan/settings_media_settings.jpg</icon>
-                        <thumb>resource://resource.images.skinicons.titan/defaultaddonvideo.png</thumb>
+                        <thumb>resource://resource.images.skinicons.titan/media.png</thumb>
                     </item>
                     <item id="3">
                         <description>Live TV</description>
@@ -119,7 +119,7 @@
                         <label2>14201</label2>
                         <onclick>ActivateWindow(PlayerSettings)</onclick>
                         <icon>resource://resource.images.skinbackgrounds.titan/settings_player_settings.jpg</icon>
-                        <thumb>resource://resource.images.skinicons.titan/DefaultAddonAudioDecoder.png</thumb>
+                        <thumb>resource://resource.images.skinicons.titan/player.png</thumb>
                     </item>
                     <item id="5">
                         <description>Addons</description>

--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -95,7 +95,7 @@
                         <label2>31400</label2>
                         <onclick>activatewindow(InterfaceSettings)</onclick>
                         <icon>resource://resource.images.skinbackgrounds.titan/settings_interface.jpg</icon>
-                        <thumb>resource://resource.images.skinicons.titan/appearance.png</thumb>
+                        <thumb>resource://resource.images.skinicons.titan/interface.png</thumb>
                     </item>
                     <item id="2">
                         <description>Media Settings</description>


### PR DESCRIPTION
new icons for media and player settings

## DEPENDS ON FOLLOWING PR:
https://github.com/marcelveldt/resource.images.skinicons.titan/pull/2

screenshot of new icons:

![2017-03-04_00-04-10](https://cloud.githubusercontent.com/assets/6510026/23577226/6c4c6134-006e-11e7-9000-5c2b292a2673.png)
