### PR TITLE
sysinfo widget: modify network add battery

### DIFF
--- a/1080i/IncludesHomeWidgets.xml
+++ b/1080i/IncludesHomeWidgets.xml
@@ -1840,6 +1840,18 @@
             <property name="DBTYPE">systeminfo</property>
             <property name="fanart">resource://resource.images.skinbackgrounds.titan/networking.jpg</property>
             <property name="plot">$INFO[Network.LinkState][CR]$LOCALIZE[443]: $INFO[System.InternetState]</property>
+            <visible>System.InternetState</visible>
+            <onclick>ActivateWindow(systeminfo)</onclick>
+        </item>
+        <item>
+            <label>$LOCALIZE[1006]:</label>
+            <label2>[CR][COLOR red]$LOCALIZE[221][/COLOR]</label2>
+            <thumb>resource://resource.images.skinicons.titan/network-down.png</thumb>
+            <property name="poster">resource://resource.images.skinicons.titan/network_poster_down.png</property>
+            <property name="DBTYPE">systeminfo</property>
+            <property name="fanart">resource://resource.images.skinbackgrounds.titan/networking-down.jpg</property>
+            <property name="plot">[COLOR red]$INFO[Network.LinkState][CR]$LOCALIZE[443]: $INFO[System.InternetState][/COLOR]</property>
+            <visible>!System.InternetState</visible>
             <onclick>ActivateWindow(systeminfo)</onclick>
         </item>
         <item>
@@ -1850,6 +1862,39 @@
             <property name="DBTYPE">systeminfo</property>
             <property name="fanart">resource://resource.images.skinbackgrounds.titan/display.jpg</property>
             <property name="plot">[CR]$INFO[System.ScreenResolution]</property>
+            <onclick>ActivateWindow(systeminfo)</onclick>
+        </item>
+        <item>
+            <label>$LOCALIZE[12395]:</label>
+            <label2>[CR][COLOR green]$INFO[System.BatteryLevel][/COLOR]</label2>
+            <thumb>resource://resource.images.skinicons.titan/battery_good.png</thumb>
+            <property name="poster">resource://resource.images.skinicons.titan/battery_good_poster.png</property>
+            <property name="DBTYPE">systeminfo</property>
+            <property name="fanart">resource://resource.images.skinbackgrounds.titan/battery_good.jpg</property>
+            <property name="plot">[CR][COLOR green]$LOCALIZE[12395]: $LOCALIZE[12321][/COLOR]</property>
+            <visible>Integer.IsGreater(System.BatteryLevel,60)</visible>
+            <onclick>ActivateWindow(systeminfo)</onclick>
+        </item>
+        <item>
+            <label>$LOCALIZE[12395]:</label>
+            <label2>[CR][COLOR yellow]$INFO[System.BatteryLevel][/COLOR]</label2>
+            <thumb>resource://resource.images.skinicons.titan/battery_low.png</thumb>
+            <property name="poster">resource://resource.images.skinicons.titan/battery_low_poster.png</property>
+            <property name="DBTYPE">systeminfo</property>
+            <property name="fanart">resource://resource.images.skinbackgrounds.titan/battery_low.jpg</property>
+            <property name="plot">[CR][COLOR yellow]$LOCALIZE[13050][/COLOR]</property>
+            <visible>Integer.IsGreater(System.BatteryLevel,20) + !Integer.IsGreater(System.BatteryLevel,60)</visible>
+            <onclick>ActivateWindow(systeminfo)</onclick>
+        </item>
+        <item>
+            <label>$LOCALIZE[12395]:</label>
+            <label2>[CR][COLOR red]$INFO[System.BatteryLevel][/COLOR]</label2>
+            <thumb>resource://resource.images.skinicons.titan/battery_critical.png</thumb>
+            <property name="poster">resource://resource.images.skinicons.titan/battery_critical_poster.png</property>
+            <property name="DBTYPE">systeminfo</property>
+            <property name="fanart">resource://resource.images.skinbackgrounds.titan/battery_critical.jpg</property>
+            <property name="plot">[CR][COLOR red]$LOCALIZE[13050][/COLOR]</property>
+            <visible>!Integer.IsGreater(System.BatteryLevel,20)</visible>
             <onclick>ActivateWindow(systeminfo)</onclick>
         </item>
     </include>


### PR DESCRIPTION
- add new battery level to widget (color and textures change on state)
- 3 states: good, low, critical

- modify network to change on state

## THIS PR DEPENDS ON TEXTURE UPDATES:
https://github.com/marcelveldt/resource.images.skinicons.titan/pull/2
https://github.com/marcelveldt/resource.images.skinbackgrounds.titan/pull/1

Screenshots of widgets showing network / internet down and new battery widget
![2017-03-04_00-20-07](https://cloud.githubusercontent.com/assets/6510026/23577316/e0da257a-0070-11e7-9be1-8976b3425d84.png)
![2017-03-04_00-20-15](https://cloud.githubusercontent.com/assets/6510026/23577317/e0db0d14-0070-11e7-9c00-c7f44a464bc1.png)
![2017-03-04_00-19-39](https://cloud.githubusercontent.com/assets/6510026/23577318/e0dc6ed4-0070-11e7-93dd-e12c70f963eb.png)
![2017-03-04_00-19-46](https://cloud.githubusercontent.com/assets/6510026/23577319/e0ddcb9e-0070-11e7-9db6-0a362c8957b9.png)
