### PR TITLE
Fix: Fixed focus on all widgets, not just the first on home page

### DIFF
--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -260,7 +260,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName2]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath2 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle2 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle2 in 'details' or 'enabled' in widgetFixedFocus2 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle2]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]520" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName2]" />
@@ -281,7 +281,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName3]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath3 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle3 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle3 in 'details' or 'enabled' in widgetFixedFocus3 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle3]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]530" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName3]" />
@@ -302,7 +302,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName4]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath4 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle4 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle4 in 'details' or 'enabled' in widgetFixedFocus4 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle4]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]540" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName4]" />
@@ -323,7 +323,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName5]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath5 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle5 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle5 in 'details' or 'enabled' in widgetFixedFocus5 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle5]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]550" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName5]" />
@@ -344,7 +344,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName6]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath6 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle6 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle6 in 'details' or 'enabled' in widgetFixedFocus6 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle6]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]560" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName6]" />
@@ -365,7 +365,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName7]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath7 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle7 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle7 in 'details' or 'enabled' in widgetFixedFocus7 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle7]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]570" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName7]" />
@@ -386,7 +386,7 @@
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName8]" />
             </include>
             <include name="widget_base" content="widget_base" condition="$PYTHON['true' if widgetPath8 else 'false']">
-                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle8 in 'details' else 'panel']" />
+                <param name="containerType" value="$PYTHON['fixedlist' if widgetStyle8 in 'details' or 'enabled' in widgetFixedFocus8 else 'panel']" />
                 <param name="contentStyle" value="$SKINSHORTCUTS[contentStyle8]" />
                 <param name="widgetid" value="$SKINSHORTCUTS[id]580" />
                 <param name="widgetName" value="$SKINSHORTCUTS[widgetName8]" />


### PR DESCRIPTION
Currently only the first widget will have fixed focus, rest of the widgets don't get the setting.